### PR TITLE
Add environment-based API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # InCircle2
+
+## API configuration
+
+API URLs are loaded from environment variables via `app.config.js`. Define the following variables before starting the app:
+
+- `API_URL_DEV` – development API endpoint
+- `API_URL_STAGING` – staging API endpoint
+- `API_URL_PROD` – production API endpoint
+
+You can export them in your shell when running Expo:
+
+```bash
+API_URL_DEV=http://localhost:9000/api \
+API_URL_STAGING=https://staging.example.com/api \
+API_URL_PROD=https://api.example.com/api \
+npm start
+```
+
+Alternatively create a `.env` file in the project root:
+
+```env
+API_URL_DEV=http://localhost:9000/api
+API_URL_STAGING=https://staging.example.com/api
+API_URL_PROD=https://api.example.com/api
+```
+
+`app/config/settings.js` chooses the correct URL based on the Expo release channel. The development URL is used when running `expo start`, the staging URL is used for builds created with `--release-channel staging`, and all other builds use the production URL.

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,12 @@
+import "dotenv/config";
+
+export default ({ config }) => {
+  return {
+    ...config,
+    extra: {
+      devApiUrl: process.env.API_URL_DEV,
+      stagingApiUrl: process.env.API_URL_STAGING,
+      prodApiUrl: process.env.API_URL_PROD,
+    },
+  };
+};

--- a/app/config/settings.js
+++ b/app/config/settings.js
@@ -1,23 +1,27 @@
 import Constants from "expo-constants";
 
+const DEFAULT_URL = "http://***.***.*.**:9000/api";
+
 const settings = {
-	// IPv4 Address (ipconfig):port
-	dev: {
-		apiUrl: "http://***.***.*.**:9000/api",
-	},
-	staging: {
-		apiUrl: "http://***.***.*.**:9000/api",
-	},
-	prod: {
-		apiUrl: "http://***.***.*.**:9000/api",
-	},
+        dev: {
+                apiUrl:
+                        Constants.manifest?.extra?.devApiUrl || DEFAULT_URL,
+        },
+        staging: {
+                apiUrl:
+                        Constants.manifest?.extra?.stagingApiUrl || DEFAULT_URL,
+        },
+        prod: {
+                apiUrl:
+                        Constants.manifest?.extra?.prodApiUrl || DEFAULT_URL,
+        },
 };
 
 const getCurrentSettings = () => {
-	if (__DEV__) return settings.dev;
-	if (Constants.manifest.releaseChannel === "staging")
-		return settings.staging;
-	return settings.prod;
+        if (__DEV__) return settings.dev;
+        if (Constants.manifest.releaseChannel === "staging")
+                return settings.staging;
+        return settings.prod;
 };
 
 export default getCurrentSettings();


### PR DESCRIPTION
## Summary
- allow providing API URLs via env vars using `Constants.manifest.extra`
- configure env vars through new `app.config.js`
- document how to set API URLs for each environment

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b7d0c5da0832ab8c0437855b576c7